### PR TITLE
fix for Amazon Linux Service Provider

### DIFF
--- a/libraries/helpers_param.rb
+++ b/libraries/helpers_param.rb
@@ -101,7 +101,7 @@ module SysctlCookbook
         when 'arch', 'exherbo'
           s['name'] = 'systemd-sysctl'
           s['provider'] = Chef::Provider::Service::Systemd
-        when 'centos', 'redhat', 'scientific', 'oracle', 'amazon'
+        when 'centos', 'redhat', 'scientific', 'oracle'
           if node['platform_version'].to_f >= 7.0
             s['name'] = 'systemd-sysctl'
             s['provider'] = Chef::Provider::Service::Systemd


### PR DESCRIPTION
### Issues Resolved

Cookbook was using Systemd service provider for Amazon Linux when it should be Init. Removed it from the case list for Systemd leaving it for Chef to decide what is the correct provider.